### PR TITLE
Fix misspelling word separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Inputs
 
 - `msg`: String to split
-- `seperator`: The delimiter to split the string. Default: `' '` (whitespace)
+- `separator`: The delimiter to split the string. Default: `' '` (whitespace)
 - `maxsplit`: Maximum number of splits. Default: `-1` (no limit)
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   msg:
     required: true
     description: String to split
-  seperator:
+  separator:
     required: false
     default: ' '
     description: The delimiter to split the string
@@ -223,5 +223,5 @@ runs:
   image: docker://winterjung/split:v1
   args:
     - ${{ inputs.msg }}
-    - ${{ inputs.seperator }}
+    - ${{ inputs.separator }}
     - ${{ inputs.maxsplit }}

--- a/main.py
+++ b/main.py
@@ -45,10 +45,10 @@ def to_outputs(results: List[str]) -> Dict[str, str]:
 
 def main():
     msg = get_action_input('msg', required=True)
-    seperator = get_action_input('seperator', required=False, default=' ')
+    separator = get_action_input('separator', required=False, default=' ')
     maxsplit = int(get_action_input('maxsplit', required=False, default='-1'))
 
-    results = split(msg, seperator, maxsplit)
+    results = split(msg, separator, maxsplit)
     outputs = to_outputs(results)
     for k, v in outputs.items():
         set_action_output(k, v)

--- a/test_main.py
+++ b/test_main.py
@@ -17,10 +17,10 @@ class TestSplit:
             (' /release split v1 ', ' ', ['', '/release', 'split', 'v1', '']),
         ],
     )
-    def test_seperator(self, msg, sep, expected):
+    def test_separator(self, msg, sep, expected):
         assert split(msg, sep=sep) == expected
 
-    def test_empty_seperator(self):
+    def test_empty_separator(self):
         with pytest.raises(ValueError):
             split('must fail', sep='')
 


### PR DESCRIPTION
There is a typo in the current parameter being received by the GH Action. Would be nice if this could be merged and fixed.