### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
   example:
     runs-on: ubuntu-latest
     steps:
-      - uses: jungwinter/split@v1
+      - uses: jungwinter/split@v2
         id: split
         with:
           msg: '/release split v1.0.0'


### PR DESCRIPTION
the current docs have a bit of a contradiction. 

In the top where it shows the parameters it mentions `separator` but in the example it uses `- uses: jungwinter/split@v1` and `v1` has a typo where it expects `seperator`. 

 