### PR TITLE
Update action.yml to use latest docker image tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -220,8 +220,7 @@ outputs:
     description: 100th element
 runs:
   using: docker
-  image: docker://python:3.9.7-alpine3.14
-  entrypoint: ./entrypoint.sh
+  image: docker://winterjung/split:v2
   args:
     - ${{ inputs.msg }}
     - ${{ inputs.separator }}


### PR DESCRIPTION
`jungwinter/split@v2` can use `docker://winterjung/split:v2` because `@v1` always use `:v1`